### PR TITLE
Fixup await chain, remove unactivated "runPromise"

### DIFF
--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -839,12 +839,10 @@ _.extend(AppRunner.prototype, {
 
     Console.enableProgressDisplay(false);
 
-    const postStartupResult = Promise.race([
-      listenPromise,
-      runPromise
-    ]).then(() => {
-      return runPostStartupCallbacks(bundleResult);
-    }).await();
+    const postStartupResult = listenPromise
+      .await()
+      .then(() => runPostStartupCallbacks(bundleResult))
+      .await();
 
     if (postStartupResult) return postStartupResult;
 


### PR DESCRIPTION
runPromise was added to the race set, but wasn't activated (but is activated below). I removed it, and also got rid of the race, since it was just one promise left.